### PR TITLE
Fix venv permission mismatch causing Phase 4b and Phase 9 to silently skip

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -212,7 +212,7 @@ Add between Phase 4 and Phase 5:
 Pulls back cue end times that linger past speech boundaries.
 
 ```bash
-scripts/venv/bin/python3 scripts/trim_to_speech.py \
+scripts/run-venv.sh scripts/trim_to_speech.py \
     "$VIDEO_FILE" \
     merged.nl.srt \
     --output trimmed.nl.srt \
@@ -268,15 +268,15 @@ That's it. No conditional logic, no Phase 10 auto-skip, no report validation in 
 
 ```bash
 # 1. Trim
-scripts/venv/bin/python3 scripts/trim_to_speech.py \
+scripts/run-venv.sh scripts/trim_to_speech.py \
     helvetica.mkv merged.nl.srt \
     --output trimmed.nl.srt --fps 25 --report trim_report.json -v
 
 # 2. Structural integrity check
-scripts/venv/bin/python3 scripts/validate_srt.py trimmed.nl.srt --summary
+scripts/run-venv.sh scripts/validate_srt.py trimmed.nl.srt --summary
 
 # 3. Re-run Phase 9 QC
-scripts/venv/bin/python3 scripts/vad_timing_check.py \
+scripts/run-venv.sh scripts/vad_timing_check.py \
     helvetica.mkv trimmed.nl.srt helvetica.en.srt \
     --report trimmed_vad.json
 

--- a/base/workflow-post.md
+++ b/base/workflow-post.md
@@ -132,7 +132,7 @@ If dual-speaker count is **below the expected range**, the translator likely mis
 Pulls back cue end times that linger past speech boundaries. Uses VAD (same approach as Phase 9) to detect where speech actually ends and trims accordingly, guarded by CPS constraints.
 
 ```bash
-scripts/venv/bin/python3 scripts/trim_to_speech.py \
+scripts/run-venv.sh scripts/trim_to_speech.py \
     "$VIDEO_FILE" \
     merged.nl.srt \
     --output trimmed.nl.srt \
@@ -312,7 +312,7 @@ python3 scripts/check_line_balance.py "${VIDEO_BASENAME}.nl.srt" --fix
 Checks subtitle timing against actual speech via WebRTC VAD.
 
 ```bash
-scripts/venv/bin/python3 scripts/vad_timing_check.py \
+scripts/run-venv.sh scripts/vad_timing_check.py \
     "$VIDEO_FILE" \
     "${VIDEO_BASENAME}.nl.srt" \
     "${VIDEO_BASENAME}.en.srt" \
@@ -344,7 +344,7 @@ scripts/venv/bin/python3 scripts/vad_timing_check.py \
 **When:** Content with slow speakers where subtitles disappear before speaker finishes.
 
 ```bash
-scripts/venv/bin/python3 scripts/extend_to_speech_lite.py \
+scripts/run-venv.sh scripts/extend_to_speech_lite.py \
     "$VIDEO_FILE" \
     "${VIDEO_BASENAME}.nl.srt" \
     -o "${VIDEO_BASENAME}.nl.srt" \

--- a/base/workflow-setup.md
+++ b/base/workflow-setup.md
@@ -60,7 +60,7 @@ If no embedded subtitles, use external `.en.srt` file.
 Documentaries and historical films often have burned-in English title cards (dates, locations, names) that are absent from the English SRT but present in foreign-language subtitles. This phase detects them by downloading a foreign subtitle from OpenSubtitles and comparing timestamps.
 
 ```bash
-scripts/venv/bin/python3 scripts/fetch_title_cards.py \
+scripts/run-venv.sh scripts/fetch_title_cards.py \
     "${VIDEO_BASENAME}.en.srt" \
     "$VIDEO_FILE" \
     --output "${WORK_DIR}/title_cards.srt" \
@@ -132,14 +132,14 @@ Classify: `< 24.5` → **24**, `≥ 24.5` → **25**. Include in checkpoint.
 
 ```bash
 # Sync external SRT
-scripts/venv/bin/python3 scripts/sync_subtitles.py "$VIDEO_FILE" source.en.srt \
+scripts/run-venv.sh scripts/sync_subtitles.py "$VIDEO_FILE" source.en.srt \
     -o "${VIDEO_BASENAME}.en.srt" -v
 
 # List embedded subtitle streams
-scripts/venv/bin/python3 scripts/sync_subtitles.py "$VIDEO_FILE" --list-streams
+scripts/run-venv.sh scripts/sync_subtitles.py "$VIDEO_FILE" --list-streams
 
 # Sync embedded stream
-scripts/venv/bin/python3 scripts/sync_subtitles.py "$VIDEO_FILE" --stream 0:s:0 \
+scripts/run-venv.sh scripts/sync_subtitles.py "$VIDEO_FILE" --stream 0:s:0 \
     -o "${VIDEO_BASENAME}.en.srt" -v
 ```
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -143,35 +143,35 @@ cd /mnt/nas/video/.claude/skills/srt-translate
 # Comedy Pipeline
 # Test 1: Translation (requires Claude subagent)
 # Test 2: Merge
-scripts/venv/bin/python3 scripts/auto_merge_cues.py \
+scripts/run-venv.sh scripts/auto_merge_cues.py \
   draft.nl.srt \
   --gap-threshold 800 --max-duration 6000 \
   --output merged.nl.srt \
   --report merge_report.json
 # Test 3: Validation
-scripts/venv/bin/python3 scripts/validate_srt.py merged.nl.srt --fps 25
+scripts/run-venv.sh scripts/validate_srt.py merged.nl.srt --fps 25
 
 # Documentary Pipeline
 # Test 4: Translation (requires Claude subagent)
 # Test 5: Merge
-scripts/venv/bin/python3 scripts/auto_merge_cues.py \
+scripts/run-venv.sh scripts/auto_merge_cues.py \
   draft.nl.srt \
   --gap-threshold 1000 --max-duration 7000 \
   --output merged.nl.srt \
   --report merge_report.json
 # Test 6: Validation
-scripts/venv/bin/python3 scripts/validate_srt.py merged.nl.srt --fps 25
+scripts/run-venv.sh scripts/validate_srt.py merged.nl.srt --fps 25
 
 # Drama Pipeline
 # Test 7: Translation (requires Claude subagent)
 # Test 8: Merge
-scripts/venv/bin/python3 scripts/auto_merge_cues.py \
+scripts/run-venv.sh scripts/auto_merge_cues.py \
   draft.nl.srt \
   --gap-threshold 1000 --max-duration 7000 \
   --output merged.nl.srt \
   --report merge_report.json
 # Test 9: Validation
-scripts/venv/bin/python3 scripts/validate_srt.py merged.nl.srt --fps 24
+scripts/run-venv.sh scripts/validate_srt.py merged.nl.srt --fps 24
 ```
 
 After merge, Phase 6 (Linguistic Review) should be run to verify merge boundary correctness — see `workflow-post.md`.

--- a/scripts/fetch_title_cards.py
+++ b/scripts/fetch_title_cards.py
@@ -27,7 +27,7 @@ from pathlib import Path
 try:
     import pysubs2
 except ImportError:
-    print("ERROR: pysubs2 not available — run via scripts/venv/bin/python3", file=sys.stderr)
+    print("ERROR: pysubs2 not available — run via scripts/run-venv.sh", file=sys.stderr)
     sys.exit(2)
 
 API_BASE = "https://api.opensubtitles.com/api/v1"

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -201,7 +201,7 @@ invoke_claude() {
 
     # --allowedTools ensures non-interactive execution
     # Unset CLAUDECODE to allow running from within a Claude Code session
-    # cd to SKILL_DIR so relative paths like scripts/venv/bin/python3 resolve correctly
+    # cd to SKILL_DIR so relative paths like scripts/run-venv.sh resolve correctly
     # and Bash(scripts/*) permission pattern matches them regardless of launch cwd.
     local exit_code
     (cd "$SKILL_DIR" && echo "$prompt" | env -u CLAUDECODE claude -p \

--- a/scripts/run-venv.sh
+++ b/scripts/run-venv.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Wrapper to invoke the venv Python interpreter from a single-level path.
+#
+# Why this exists:
+#   The orchestrator grants Bash permission via "Bash(scripts/*)" which only
+#   matches a single directory level.  The real interpreter lives at
+#   scripts/venv/bin/python3 (three levels deep) and therefore falls outside
+#   that pattern.  This wrapper lives at scripts/run-venv.sh (one level) so
+#   it matches the allowlist, and it resolves the venv path absolutely so it
+#   works regardless of the current working directory.
+#
+# Usage:
+#   scripts/run-venv.sh scripts/trim_to_speech.py [args...]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_PYTHON="${SCRIPT_DIR}/venv/bin/python3"
+
+if [[ ! -x "$VENV_PYTHON" ]]; then
+    echo "ERROR: venv not found at ${VENV_PYTHON}" >&2
+    echo "Run: scripts/setup.sh" >&2
+    exit 1
+fi
+
+exec "$VENV_PYTHON" "$@"

--- a/scripts/vad_timing_check.py
+++ b/scripts/vad_timing_check.py
@@ -11,18 +11,18 @@ Performance: Audio extraction ~20s (cached), full VAD ~3s, analysis < 1s.
 Always runs on all cues — no selective mode needed.
 
 Usage:
-    venv/bin/python3 scripts/vad_timing_check.py VIDEO NL_SRT EN_SRT [options]
+    scripts/run-venv.sh scripts/vad_timing_check.py VIDEO NL_SRT EN_SRT [options]
 
 Examples:
     # Standard QC
-    venv/bin/python3 scripts/vad_timing_check.py movie.mkv movie.nl.srt movie.en.srt
+    scripts/run-venv.sh scripts/vad_timing_check.py movie.mkv movie.nl.srt movie.en.srt
 
     # Stricter detection, save report
-    venv/bin/python3 scripts/vad_timing_check.py movie.mkv movie.nl.srt movie.en.srt \\
+    scripts/run-venv.sh scripts/vad_timing_check.py movie.mkv movie.nl.srt movie.en.srt \\
         --threshold 300 --report logs/vad_report.json
 
     # More aggressive noise filtering
-    venv/bin/python3 scripts/vad_timing_check.py movie.mkv movie.nl.srt movie.en.srt \\
+    scripts/run-venv.sh scripts/vad_timing_check.py movie.mkv movie.nl.srt movie.en.srt \\
         --aggressiveness 3
 """
 import argparse


### PR DESCRIPTION
Add scripts/run-venv.sh wrapper that resolves the venv Python interpreter
via absolute path from a single-level path (scripts/*), fixing the
allowlist pattern mismatch where scripts/venv/bin/python3 (three levels
deep) fell outside the Bash(scripts/*) glob. Update all workflow docs,
evals, and script references to use the wrapper.

Fixes #7

https://claude.ai/code/session_01Wp769XpNyZJRLxSr7rEf4L