### PR TITLE
Add cumulative glossary for cross-batch translation continuity

### DIFF
--- a/base/workflow-translate.md
+++ b/base/workflow-translate.md
@@ -169,6 +169,43 @@ After each batch, write to `$BATCH_CONTEXT_DIR/batch{N}_context.md`:
 
 The **Speaker Changes** section is critical for batch continuity — the next batch must know who was speaking at the end of the previous batch to correctly place `[SC]` on its first cue.
 
+### Cumulative glossary
+
+The glossary file (`$GLOSSARY_FILE`) persists across all batches and invocations. Unlike batch context summaries (which only carry the last 2 forward), the glossary preserves every translation decision for the entire file.
+
+**After each batch**, read the current glossary (if it exists), then write the updated version. Use **append-based updates** — add new entries, never remove existing ones. Only add entries that differ from the defaults in `references/translation-defaults.md`.
+
+Write the glossary in this format:
+
+```markdown
+# Translation Glossary
+<!-- Auto-maintained across batches. Do not delete entries. -->
+
+## Characters & Register
+<!-- character name → Dutch name (if adapted) + T/V register -->
+<!-- e.g. "John → Jan (V, formal throughout)" -->
+
+## Recurring Terminology
+<!-- English term → chosen Dutch translation -->
+<!-- Only terms where the choice matters for consistency -->
+
+## Proper Nouns & Titles
+<!-- Names, places, show-specific terms that must stay consistent -->
+
+## Recurring Phrases & Catchphrases
+<!-- Character-specific expressions, running gags, repeated lines -->
+
+## Style Notes
+<!-- Tone decisions, narrative voice, any cross-batch style choices -->
+```
+
+**Rules:**
+- Read the glossary at the start of each batch to stay consistent
+- After each batch, add any new entries discovered during translation
+- If a previous entry needs correction (e.g. you learned more context), update the entry in-place and add a note (e.g. `← updated batch 5: now formal`)
+- Keep entries concise — one line per term/decision
+- The glossary only grows; never delete entries unless they were factually wrong
+
 ### Post-batch validation
 
 ```bash
@@ -185,9 +222,12 @@ Update checkpoint:
 ## Translation State (Phase 2)
 - **Batches completed:** [N of M]
 - **Output cues:** [count]
+- **Glossary entries:** [count]
 - **Status:** COMPLETE
 
 ## Terminology
 ## Register
 ## Known Issues
 ```
+
+The cumulative glossary at `$GLOSSARY_FILE` should now contain all translation decisions made during Phase 2. It will be available for future runs (e.g. translating subsequent episodes of a series).

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -110,6 +110,7 @@ BATCH_CONTEXT_DIR="${LOG_DIR}/batch_context_${VIDEO_BASENAME}"
 OUTPUT_SRT="${VIDEO_DIR}/${VIDEO_BASENAME}.nl.srt"
 SOURCE_SRT="${VIDEO_DIR}/${VIDEO_BASENAME}.en.srt"
 WORK_DIR="${LOG_DIR}/work_${VIDEO_BASENAME}"
+GLOSSARY_FILE="${WORK_DIR}/translation_glossary.md"
 
 mkdir -p "$LOG_DIR" "$BATCH_CONTEXT_DIR" "$WORK_DIR"
 
@@ -369,6 +370,12 @@ run_translation() {
             fi
         done
 
+        # Load cumulative glossary (persists across all invocations)
+        local glossary_content=""
+        if [[ -f "$GLOSSARY_FILE" ]]; then
+            glossary_content="$(cat "$GLOSSARY_FILE")"
+        fi
+
         invoke_claude --model "$MODEL_TRANSLATE" "Translation batches ${current_batch}-${end_of_group}" \
             "$SHARED_CONSTRAINTS" \
             "$WORKFLOW_TRANSLATE" \
@@ -394,6 +401,7 @@ Translate cues ${cue_start} through ${cue_end} of the source subtitle file.
 - Output SRT (write here): ${WORK_DIR}/draft.nl.srt
 - Scripts dir: ${SKILL_DIR}/scripts
 - Batch context dir: ${BATCH_CONTEXT_DIR}
+- Glossary file: ${GLOSSARY_FILE}
 - Work dir (temp files): ${WORK_DIR}
 
 **Working directory:** ${WORK_DIR}
@@ -409,7 +417,15 @@ else
     echo "**Continuing from batch $current_batch.** Append to existing ${WORK_DIR}/draft.nl.srt with \`cat >>\`."
 fi)
 
-## Previous Context
+## Cumulative Glossary
+
+$(if [[ -n "$glossary_content" ]]; then
+    echo "$glossary_content"
+else
+    echo "No glossary yet — you will create it after your first batch."
+fi)
+
+## Previous Batch Context
 
 $(if [[ -n "$prev_context" ]]; then
     echo "$prev_context"
@@ -427,7 +443,8 @@ $(cat "$CHECKPOINT_FILE")
 2. Write each batch directly to ${WORK_DIR}/draft.nl.srt (NEVER to terminal)
 3. Run per-batch grammar verification after each batch
 4. Write batch context summary after each batch to ${BATCH_CONTEXT_DIR}/batchN_context.md
-5. After the last batch in this group, update the checkpoint: ${CHECKPOINT_FILE}
+5. After each batch, update the cumulative glossary at ${GLOSSARY_FILE} (see workflow instructions)
+6. After the last batch in this group, update the checkpoint: ${CHECKPOINT_FILE}
 EOF
 
         current_batch=$(( end_of_group + 1 ))


### PR DESCRIPTION
Adds a persistent glossary file (translation_glossary.md) that accumulates
character names, register choices, terminology, proper nouns, and style
decisions across all translation batches and invocations. Unlike batch
context summaries (which only carry the last 2 forward), the glossary
preserves every translation decision for the entire file, preventing
terminology drift during long translations.

Changes:
- orchestrate.sh: Define GLOSSARY_FILE path, load and pass glossary
  content to each translation invocation, add glossary path to prompt
- workflow-translate.md: Add glossary format specification, maintenance
  rules (append-only updates), and per-batch update instructions

Closes #10

https://claude.ai/code/session_01HMVqo8dfK2Kn6NA1FS9xMw